### PR TITLE
Convert mobile menu to overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     </button>
 
     <!-- Mobile Menu Dropdown -->
-    <div id="mobile-menu-dropdown" class="absolute right-4 top-16 bg-white text-black shadow-lg rounded-lg overflow-hidden z-50 w-48">
+    <div id="mobile-menu-dropdown" class="fixed inset-0 bg-white text-black z-50 hidden p-6 overflow-y-auto">
       <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-run-query" data-tooltip="Run Query">
         <svg class="w-5 h-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
           <polygon points="5,3 19,12 5,21"></polygon>

--- a/query.js
+++ b/query.js
@@ -124,10 +124,16 @@ window.addEventListener('keydown', e => {
   }
 });
 
-document.getElementById('toggle-json')?.addEventListener('click', () => openModal('json-panel'));
-document.getElementById('toggle-queries')?.addEventListener('click', () => openModal('queries-panel'));
-document.getElementById('toggle-help')?.addEventListener('click', () => openModal('help-panel'));
-document.getElementById('toggle-templates')?.addEventListener('click', () => openModal('templates-panel'));
+// Consolidated desktop modal toggles
+const panelToggles = {
+  'toggle-json': 'json-panel',
+  'toggle-queries': 'queries-panel',
+  'toggle-help': 'help-panel',
+  'toggle-templates': 'templates-panel'
+};
+Object.entries(panelToggles).forEach(([btnId, panelId]) => {
+  document.getElementById(btnId)?.addEventListener('click', () => openModal(panelId));
+});
 document.querySelectorAll('.collapse-btn').forEach(btn=>{
   btn.addEventListener('click', () => closeModal(btn.dataset.target));
 });
@@ -3169,14 +3175,21 @@ const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
 const mobileMenuDropdown = document.getElementById('mobile-menu-dropdown');
 
 if (mobileMenuToggle && mobileMenuDropdown) {
-  // Toggle dropdown visibility when hamburger is clicked
+  // Toggle overlay visibility when hamburger is clicked
   mobileMenuToggle.addEventListener('click', () => {
     mobileMenuDropdown.classList.toggle('show');
   });
-  
-  // Close dropdown when clicking outside
-  document.addEventListener('click', (e) => {
-    if (!mobileMenuToggle.contains(e.target) && !mobileMenuDropdown.contains(e.target)) {
+
+  // Close when tapping blank area of the overlay
+  mobileMenuDropdown.addEventListener('click', (e) => {
+    if (e.target === mobileMenuDropdown) {
+      mobileMenuDropdown.classList.remove('show');
+    }
+  });
+
+  // Escape key closes the overlay
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && mobileMenuDropdown.classList.contains('show')) {
       mobileMenuDropdown.classList.remove('show');
     }
   });
@@ -3184,38 +3197,25 @@ if (mobileMenuToggle && mobileMenuDropdown) {
   // Mobile menu item click handlers
   document.getElementById('mobile-run-query')?.addEventListener('click', () => {
     mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the run query button
     document.getElementById('run-query-btn')?.click();
   });
-  
+
   document.getElementById('mobile-download')?.addEventListener('click', () => {
     mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the download button
     document.getElementById('download-btn')?.click();
   });
-  
-  document.getElementById('mobile-toggle-json')?.addEventListener('click', () => {
-    mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the JSON toggle button
-    document.getElementById('toggle-json')?.click();
-  });
-  
-  document.getElementById('mobile-toggle-queries')?.addEventListener('click', () => {
-    mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the queries toggle button
-    document.getElementById('toggle-queries')?.click();
-  });
-  
-  document.getElementById('mobile-toggle-help')?.addEventListener('click', () => {
-    mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the help toggle button
-    document.getElementById('toggle-help')?.click();
-  });
-  
-  document.getElementById('mobile-toggle-templates')?.addEventListener('click', () => {
-    mobileMenuDropdown.classList.remove('show');
-    // Trigger the same action as the templates toggle button
-    document.getElementById('toggle-templates')?.click();
+
+  const mobilePanelToggles = {
+    'mobile-toggle-json': 'json-panel',
+    'mobile-toggle-queries': 'queries-panel',
+    'mobile-toggle-help': 'help-panel',
+    'mobile-toggle-templates': 'templates-panel'
+  };
+  Object.entries(mobilePanelToggles).forEach(([btnId, panelId]) => {
+    document.getElementById(btnId)?.addEventListener('click', () => {
+      mobileMenuDropdown.classList.remove('show');
+      openModal(panelId);
+    });
   });
 }
 

--- a/styles.css
+++ b/styles.css
@@ -199,16 +199,18 @@ input, textarea, select, [contenteditable] {
 }
 
 #mobile-menu-dropdown {
-  transform: translateY(-10px);
-  opacity: 0;
-  transition: transform 0.2s ease, opacity 0.2s ease;
-  pointer-events: none;
+  position: fixed;
+  inset: 0;
+  display: none;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.97);
+  backdrop-filter: blur(12px);
+  overflow-y: auto;
+  z-index: var(--z-overlay);
 }
 
 #mobile-menu-dropdown.show {
-  transform: translateY(0);
-  opacity: 1;
-  pointer-events: auto;
+  display: flex;
 }
 
 #mobile-menu-dropdown div {


### PR DESCRIPTION
## Summary
- make the mobile menu a full‑screen overlay
- adjust styles for overlay menu
- tweak JS handlers for closing the menu

## Testing
- `git status --short`
