### PR TITLE
Fix mobile menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     </button>
 
     <!-- Mobile Menu Dropdown -->
-    <div id="mobile-menu-dropdown" class="fixed inset-0 bg-white text-black z-50 hidden p-6 overflow-y-auto">
+    <div id="mobile-menu-dropdown" class="modal-panel hidden text-black p-6 overflow-y-auto">
       <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-run-query" data-tooltip="Run Query">
         <svg class="w-5 h-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
           <polygon points="5,3 19,12 5,21"></polygon>

--- a/styles.css
+++ b/styles.css
@@ -200,13 +200,16 @@ input, textarea, select, [contenteditable] {
 
 #mobile-menu-dropdown {
   position: fixed;
-  inset: 0;
+  top: var(--header-height);
+  left: 0;
+  width: 100vw;
+  height: calc(100vh - var(--header-height));
   display: none;
   flex-direction: column;
   background: rgba(255, 255, 255, 0.97);
   backdrop-filter: blur(12px);
   overflow-y: auto;
-  z-index: calc(var(--z-overlay) + 1);
+  z-index: var(--z-condition-panel);
 }
 
 #mobile-menu-dropdown.show {


### PR DESCRIPTION
## Summary
- align mobile menu overlay with modal styling so it uses same overlay behavior

## Testing
- `npm test` *(fails: Could not read package.json)*