### PR TITLE
Improve mobile menu overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,13 +113,21 @@
 
     <!-- Mobile Menu Dropdown -->
     <div id="mobile-menu-dropdown" class="modal-panel hidden text-black p-6 overflow-y-auto">
-      <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-run-query" data-tooltip="Run Query">
+      <div class="flex justify-end mb-4">
+        <button class="collapse-btn p-1.5 rounded hover:bg-gray-200 focus:outline-none transition-colors" data-target="mobile-menu-dropdown" aria-label="Close">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="#374151" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5">
+            <line x1="4" y1="4" x2="16" y2="16" />
+            <line x1="16" y1="4" x2="4" y2="16" />
+          </svg>
+        </button>
+      </div>
+      <div class="mobile-menu-item border-b border-gray-200 hover:bg-gray-100" id="mobile-run-query" data-tooltip="Run Query">
         <svg class="w-5 h-5 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
           <polygon points="5,3 19,12 5,21"></polygon>
         </svg>
         <span>Run Query</span>
       </div>
-      <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-download" data-tooltip="Download Results">
+      <div class="mobile-menu-item border-b border-gray-200 hover:bg-gray-100" id="mobile-download" data-tooltip="Download Results">
         <svg class="w-5 h-5 text-gray-800" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M4 16v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/>
           <path d="M7 10l5 5 5-5"/>
@@ -127,7 +135,7 @@
         </svg>
         <span>Download</span>
       </div>
-      <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-toggle-json" data-tooltip="Show Query JSON">
+      <div class="mobile-menu-item border-b border-gray-200 hover:bg-gray-100" id="mobile-toggle-json" data-tooltip="Show Query JSON">
         <svg class="w-5 h-5 text-yellow-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
           <polyline points="14 2 14 8 20 8"></polyline>
@@ -137,7 +145,7 @@
         </svg>
         <span>JSON</span>
       </div>
-      <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-toggle-queries" data-tooltip="Show Query History">
+      <div class="mobile-menu-item border-b border-gray-200 hover:bg-gray-100" id="mobile-toggle-queries" data-tooltip="Show Query History">
         <svg class="history-animated w-5 h-5 text-blue-600" viewBox="0 0 24 24" fill="none">
           <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="1.5" stroke-dasharray="0.5 3.5"/>
           <path d="M22 12C22 6.47715 17.5228 2 12 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
@@ -150,7 +158,7 @@
         </svg>
         <span>Queries</span>
       </div>
-      <div class="p-2 border-b border-gray-200 flex items-center gap-2 hover:bg-gray-100" id="mobile-toggle-templates" data-tooltip="Query Templates">
+      <div class="mobile-menu-item border-b border-gray-200 hover:bg-gray-100" id="mobile-toggle-templates" data-tooltip="Query Templates">
         <svg class="w-5 h-5 text-gray-800" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"></path>
           <path d="M8 2v4"></path>
@@ -159,7 +167,7 @@
         </svg>
         <span>Templates</span>
       </div>
-      <div class="p-2 flex items-center gap-2 hover:bg-gray-100" id="mobile-toggle-help" data-tooltip="Show Help">
+      <div class="mobile-menu-item hover:bg-gray-100" id="mobile-toggle-help" data-tooltip="Show Help">
         <svg class="w-5 h-5 text-purple-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="10"></circle>
           <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>

--- a/query.js
+++ b/query.js
@@ -3249,6 +3249,7 @@ document.querySelectorAll('.collapse-btn').forEach(btn => {
     if (!panel) return;
     // For modal close buttons, just close the modal (add 'hidden')
     panel.classList.add('hidden');
+    panel.classList.remove('show'); // for mobile menu dropdown
     overlay.classList.remove('show');
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -221,6 +221,15 @@ input, textarea, select, [contenteditable] {
   transition: background-color 0.15s ease;
 }
 
+/* Ensure consistent sizing for mobile menu options */
+.mobile-menu-item {
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
 /* Responsive Header Controls */
 /* Note: CSS variables are not supported in media queries in all browsers, so we keep 900px but document the variable for future use in JS or preprocessors. */
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- add a close button to the mobile menu overlay
- ensure mobile menu options all use the same size
- dismiss 'show' class when closing overlays

## Testing
- `npm test` *(fails: Could not read package.json)*