### PR TITLE
Switch to ExcelJS for freeze panes

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,8 @@
       </div>
     </div><!-- end templates-panel -->
   </div>
-<script src="https://cdn.sheetjs.com/xlsx-0.20.2/package/dist/xlsx.full.min.js"></script>
+<!-- ExcelJS for generating spreadsheets with freeze panes support -->
+<script src="https://cdn.jsdelivr.net/npm/exceljs@4.3.0/dist/exceljs.min.js"></script>
   <script src="fieldDefs.js"></script>
   <script src="tooltips.js"></script>
   <script src="excel.js"></script>


### PR DESCRIPTION
## Summary
- remove SheetJS dependency and import ExcelJS from CDN
- rewrite `excel.js` to generate spreadsheets using ExcelJS and freeze the header row

## Testing
- `node --check excel.js`

------
https://chatgpt.com/codex/tasks/task_b_683e0669922c8327be043ff9b2ac066f