### PR TITLE
Show verified period circulation in dashboard

### DIFF
--- a/cache-bust.json
+++ b/cache-bust.json
@@ -1,5 +1,5 @@
 {
-  "version": "de36589023ff4f62",
+  "version": "d1a2238844b1af01",
   "generatedBy": "scripts/updateCacheBusting.mjs",
   "assets": {
     "assets/app-icon-16.png": "6645731d86da1071",
@@ -239,8 +239,8 @@
     "src/ui/dashboard/kpiDashboard.js": "e1b9f14b3b9089f8",
     "src/ui/dashboard/kpiDashboardModel.js": "fa4c42b18c1245e5",
     "src/ui/dashboard/kpiDashboardView.js": "82508c550975ada6",
-    "src/ui/dashboard/libraryDashboardModel.js": "b7798cb959dc03ac",
-    "src/ui/dashboard/libraryDashboardView.js": "6303432a0a72ec23",
+    "src/ui/dashboard/libraryDashboardModel.js": "e003654be893fc6e",
+    "src/ui/dashboard/libraryDashboardView.js": "60c31bbd3423a9c3",
     "src/ui/field-picker/buildableFieldPreview.js": "8abd486bb0a87fe2",
     "src/ui/field-picker/fieldPicker.js": "526a1bf934f5dd74",
     "src/ui/field-picker/fieldPickerModal.js": "e14c2173b1a2cc42",

--- a/docs/LIBRARY_DASHBOARD.md
+++ b/docs/LIBRARY_DASHBOARD.md
@@ -34,7 +34,7 @@ The private MLP environment owns:
 
 `library_dashboard` returns a JSON object with `schema_version: 1`. Its principal groups are:
 
-- `circulation`: period checkouts, renewals, in-house use, holds, and demand ratios;
+- `circulation`: period checkouts, renewals, in-house use, holds, demand ratios, a plain reporting-period label, and coverage boundaries;
 - `collection`: current items and titles, lifetime checkout and renewal counters, recent-use rate, never-used items, item age, and price coverage;
 - `patrons`: current, active, newly registered, currently borrowing, currently holding, and soon-expiring patron counts;
 - `circulation_trend`: reporting-period transaction points;
@@ -50,9 +50,11 @@ The UI must treat absent groups as unavailable, not as zero. Every production re
 
 The circulation transaction baseline follows the established BLUEcloud contract:
 
-- checkouts: `Charge Item Part B`;
-- renewals: `Renew Item`;
+- checkouts: ordinary and reserve item checkouts, counted as items or pieces circulated;
+- renewals: ordinary and reserve item renewals;
 - patron renewals (`Renew User Part B`) are excluded.
+
+`circulation.period_label` names the requested or effective reporting period. `coverage_complete`, `coverage_start`, and `coverage_end` distinguish a complete 90-, 365-, or 730-day window from a shorter retained-history window. The interface preserves that label instead of converting it to a numeric placeholder. Demand rankings are ordered by the selected period's checkout volume.
 
 Current holdings come from current item records. Item creation transactions must not be labeled as holdings. Lifetime item checkout/renewal counters must not be plotted as historical monthly transactions.
 
@@ -66,7 +68,7 @@ The client automatically refreshes the aggregate response while the dashboard is
 - item snapshots on a bounded recurring schedule;
 - patron aggregates on a bounded recurring schedule.
 
-The production snapshot stores each item scope, patron scope, and ranking once. Requested dashboard views are materialized from those compact dimensions, so activity-window and cross-filter responses do not duplicate the same breakdowns thousands of times. The same current library and item-type counts inform the Query smart planner: exact policy filters with smaller estimated candidate sets are safely evaluated first, while query meaning remains unchanged.
+The production snapshot stores each item scope, patron scope, and reporting-window transaction scope once. Requested dashboard views are materialized from those compact dimensions, so activity-window and cross-filter responses do not duplicate full source records. The same current library and item-type counts inform the Query smart planner: exact policy filters with smaller estimated candidate sets are safely evaluated first, while query meaning remains unchanged.
 
 Short server-side caching is intentional. It prevents multiple open browser tabs from launching duplicate full-catalog or full-patron scans while keeping the displayed data current. A response is stale when its source-specific age exceeds the backend policy; the server should return the last verified snapshot with an explicit stale warning rather than silently presenting it as current.
 

--- a/src/ui/dashboard/libraryDashboardModel.js
+++ b/src/ui/dashboard/libraryDashboardModel.js
@@ -4,7 +4,11 @@ function finiteNumber(value) {
 }
 
 function normalizeMetricGroup(group = {}) {
-  return Object.fromEntries(Object.entries(group || {}).map(([key, value]) => [key, finiteNumber(value)]));
+  return Object.fromEntries(Object.entries(group || {}).map(([key, value]) => {
+    if (typeof value === 'boolean') return [key, value];
+    if (typeof value === 'string' && value.trim() && !Number.isFinite(Number(value))) return [key, value];
+    return [key, finiteNumber(value)];
+  }));
 }
 
 function normalizeSeries(series = []) {

--- a/src/ui/dashboard/libraryDashboardView.js
+++ b/src/ui/dashboard/libraryDashboardView.js
@@ -34,8 +34,12 @@ function metricCard(label, value, detail, tone = '') {
 
 function rankedBars(items, key, emptyText = 'No data is available for this breakdown.') {
   if (!items.length) return `<p class="kpi-chart-empty">${escapeHtml(emptyText)}</p>`;
-  const maximum = Math.max(1, ...items.map(item => Number(item[key] || item.value || 0)));
-  return `<ol class="kpi-ranking">${items.slice(0, 10).map(item => {
+  const ranked = [...items].sort((left, right) =>
+    Number(right[key] || right.value || 0) - Number(left[key] || left.value || 0)
+    || String(left.label || left.code || '').localeCompare(String(right.label || right.code || ''))
+  );
+  const maximum = Math.max(1, ...ranked.map(item => Number(item[key] || item.value || 0)));
+  return `<ol class="kpi-ranking">${ranked.slice(0, 10).map(item => {
     const value = Number(item[key] || item.value || 0);
     return `<li>
       <span class="kpi-ranking__label" title="${escapeHtml(item.label || item.code || 'Unknown')}">${escapeHtml(item.label || item.code || 'Unknown')}</span>

--- a/tests/unit/ui/libraryDashboardModelLogic.mjs
+++ b/tests/unit/ui/libraryDashboardModelLogic.mjs
@@ -6,13 +6,15 @@ test('library dashboard normalizes aggregate groups and filter metadata', () => 
   const dashboard = normalizeLibraryDashboard({
     schema_version: 1,
     collection: { items: '120', titles: 90 },
-    circulation: { checkouts: '45' },
+    circulation: { checkouts: '45', period_label: 'Recent 90 days', coverage_complete: true },
     patrons: { total: 32 },
     library_breakdown: [{ label: 'Main', checkouts: '30' }],
     filters: { libraries: [{ value: 'MAIN', label: 'Main' }], item_types: ['BOOK'] }
   });
   assert.equal(dashboard.collection.items, 120);
   assert.equal(dashboard.circulation.checkouts, 45);
+  assert.equal(dashboard.circulation.period_label, 'Recent 90 days');
+  assert.equal(dashboard.circulation.coverage_complete, true);
   assert.equal(dashboard.libraryBreakdown[0].checkouts, 30);
   assert.equal(dashboard.filters.libraries[0].value, 'MAIN');
   assert.deepEqual(dashboard.availability, { circulation: true, collection: true, patrons: true });

--- a/tests/unit/ui/libraryDashboardViewLogic.mjs
+++ b/tests/unit/ui/libraryDashboardViewLogic.mjs
@@ -30,6 +30,21 @@ test('overview renders demand rankings when the transaction aggregate is availab
   assert.match(html, /kpi-ranking__label[^>]*>BOOK</);
 });
 
+test('demand rankings put the highest period activity first', () => {
+  const dashboard = normalizeLibraryDashboard({
+    circulation: { checkouts: 45, period_label: 'Recent 90 days' },
+    collection: { items: 120 },
+    library_breakdown: [
+      { label: 'Lower', checkouts: 5 },
+      { label: 'Higher', checkouts: 40 }
+    ]
+  });
+
+  const html = renderLibraryDashboard(dashboard, 'overview');
+  assert.ok(html.indexOf('>Higher</span>') < html.indexOf('>Lower</span>'));
+  assert.match(html, /Recent 90 days/);
+});
+
 test('dashboard intro names the selected aggregate scope when labels are absent', () => {
   const dashboard = normalizeLibraryDashboard({
     scope: { library: 'MSU-GRANT', item_type: 'BOOK', active_window_days: 90 },


### PR DESCRIPTION
## Summary
- preserve rolling-period labels and coverage flags from the private aggregate feed
- rank branch and item-type demand by the selected circulation metric
- document the verified checkout and item-renewal command contract

## Validation
- 986 private backend tests pass
- 277 frontend unit tests pass
- ESLint and cache-bust validation pass
- browser smoke test passes

The public repository contains presentation and contract updates only; Sirsi aggregation code and data remain private.